### PR TITLE
fix: remove sale link by purchase id

### DIFF
--- a/src/hooks/usePurchaseInsertMutation.ts
+++ b/src/hooks/usePurchaseInsertMutation.ts
@@ -29,7 +29,7 @@ export const usePurchaseInsertMutation = ({
             const { error: deleteError } = await supabase
                 .from("sale_purchases")
                 .delete()
-                .eq("sale_id", purchase_id)
+                .eq("purchase_id", purchase_id)
             if (deleteError) throw deleteError
 
             const { error: insertError } = await supabase


### PR DESCRIPTION
## Summary
- delete sale_purchases links using purchase_id instead of sale_id

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f0bf6ea88331aca7fd60e32c2012